### PR TITLE
Delete App Module

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -11,7 +11,6 @@
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/app" />
             <option value="$PROJECT_DIR$/forceupdate" />
           </set>
         </option>

--- a/README.md
+++ b/README.md
@@ -8,12 +8,60 @@ Help the user to implement the force update of the application by just providing
 
 ```groovy
 allprojects {
-repositories {
-maven { url 'https://jitpack.io' }
-}
+    repositories {
+        maven { url 'https://jitpack.io' }
+    }
 }
 ```
 ### Dependency
 ```groovy
-implementation 'com.github.Abdulrahman-AlGhamdi:ForceUpdate:0.1.2'
+implementation 'com.github.Abdulrahman-AlGhamdi:ForceUpdate:0.1.3'
+```
+
+## Usage
+
+* First  : call `ForceUpdateManager` helper class
+* Second : in the constructor you must provide the Activity and APK_LINK
+* Third  : call `updateApplication` to start force update process
+
+```kotlin
+ForceUpdateManager(
+    activity = this,
+    apkLink = "APK_LINK"
+).updateApplication()
+```
+
+Finally, if you want to customize the force update design you can add:
+    * Application Logo
+    * Version Code
+    * Version Name
+    * Application Name
+
+```kotlin
+ForceUpdateManager(
+    activity = this,
+    apkLink = "APK_LINK",
+    logo = R.drawable.application_logo,
+    versionCode = BuildConfig.VERSION_CODE,
+    versionName = BuildConfig.VERSION_NAME,
+    applicationName = getString(R.string.app_name)
+).isApplicationUpdated()
+```
+
+## License
+
+```
+Copyright 2021 Abdulrahman-AlGhamdi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 ```

--- a/forceupdate/src/main/java/com/android/forceupdate/manager/ForceUpdateManager.kt
+++ b/forceupdate/src/main/java/com/android/forceupdate/manager/ForceUpdateManager.kt
@@ -15,7 +15,7 @@ class ForceUpdateManager(
     private val applicationName: String? = null
 ) {
 
-    fun isApplicationUpdated() {
+    fun updateApplication() {
         val intent = Intent(activity, ForceUpdateActivity::class.java).apply {
             this.putExtra(EXTRA_LOGO_IMAGE, logo)
             this.putExtra(EXTRA_APK_LINK, apkLink)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,2 @@
 include ':forceupdate'
-include ':app'
 rootProject.name = "ForceUpdate"


### PR DESCRIPTION
deleting the app project module and keeping only the force update library mudule, hinding some of the hilt generated classes from the global search, change the name of the function that is called to init the force update process from isApplicationUpdated to updateApplication, updte README file