### PR TITLE
Fix Buffer & Install Failure Bug

### DIFF
--- a/forceupdate/src/main/java/com/android/forceupdate/broadcast/InstallBroadcastReceiver.kt
+++ b/forceupdate/src/main/java/com/android/forceupdate/broadcast/InstallBroadcastReceiver.kt
@@ -27,11 +27,6 @@ internal class InstallBroadcastReceiver : BroadcastReceiver() {
                 val installIntent = intent.getParcelableExtra(EXTRA_INTENT) as? Intent
                 context.startActivity(installIntent?.addFlags(FLAG_ACTIVITY_NEW_TASK))
             }
-            STATUS_FAILURE -> {
-                localFile.delete()
-                bundle.putParcelable(EXTRA_BUNDLE, InstallFailure)
-                resultReceiver?.send(1, bundle)
-            }
             STATUS_SUCCESS -> {
                 localFile.delete()
                 bundle.putParcelable(EXTRA_BUNDLE, InstallSucceeded)
@@ -41,13 +36,10 @@ internal class InstallBroadcastReceiver : BroadcastReceiver() {
                 bundle.putParcelable(EXTRA_BUNDLE, InstallCanceled)
                 resultReceiver?.send(1, bundle)
             }
-            STATUS_FAILURE_STORAGE -> {
-                bundle.putParcelable(EXTRA_BUNDLE, InstallError(STORAGE_FULL))
-                resultReceiver?.send(1, bundle)
-            }
             else -> {
                 intent.getStringExtra(EXTRA_STATUS_MESSAGE)?.let { message ->
-                    bundle.putParcelable(EXTRA_BUNDLE, InstallError(message))
+                    localFile.delete()
+                    bundle.putParcelable(EXTRA_BUNDLE, InstallFailure(message))
                     resultReceiver?.send(1, bundle)
                 }
             }
@@ -55,13 +47,8 @@ internal class InstallBroadcastReceiver : BroadcastReceiver() {
     }
 
     sealed class InstallStatus: Parcelable {
-        @Parcelize object InstallFailure : InstallStatus(), Parcelable
         @Parcelize object InstallCanceled : InstallStatus(), Parcelable
         @Parcelize object InstallSucceeded : InstallStatus(), Parcelable
-        @Parcelize data class InstallError(val message: String) : InstallStatus(), Parcelable
-    }
-
-    companion object {
-        private const val STORAGE_FULL = "Not enough storage, please erase some files"
+        @Parcelize data class InstallFailure(val message: String) : InstallStatus(), Parcelable
     }
 }

--- a/forceupdate/src/main/java/com/android/forceupdate/ui/ForceUpdateActivity.kt
+++ b/forceupdate/src/main/java/com/android/forceupdate/ui/ForceUpdateActivity.kt
@@ -111,15 +111,12 @@ internal class ForceUpdateActivity : AppCompatActivity() {
         lifecycleScope.launchWhenStarted {
             viewModel.installApk(localFile).collect {
                 when (it) {
-                    InstallFailure -> {
-                        customView(START_UPDATE)
-                    }
                     InstallCanceled -> {
                         customView(START_INSTALL)
                     }
-                    is InstallError -> {
+                    is InstallFailure -> {
                         Snackbar.make(binding.root, it.message, Snackbar.LENGTH_SHORT).show()
-                        customView(START_INSTALL)
+                        customView(START_UPDATE)
                     }
                     InstallSucceeded -> {
                         finish()


### PR DESCRIPTION
after writing the file to the internal storage it become unreadable so the fix was make the file readable and increasing the writing speed. resolve the issue when there is something wrong with the installation the library will delete the file and direct the user to the download the file again