### PR TITLE
Fix Document File Class & Custom Loading Animation

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,22 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ forceUpdateManager.checkAppVersion(updateVersion = 2)
     * In the constructor provide the APK link
     * Provide a header to the download manger if you need
     * Make the force update optional or not
+    * Change the loading animation of the force update screen by adding the file name that ends with `.json` as an argument \\this file must be in the assets folder
 
 ```kotlin
 forceUpdateManager.updateApplication(apkLink = "APK_LINK")
@@ -54,7 +55,8 @@ or
 forceUpdateManager.updateApplication(
     apkLink = "APK_LINK",
     header = Pair("header", "value"),
-    optional = true
+    optional = true,
+    animation = "loading.json"
 )
 ```
 

--- a/forceupdate/src/main/java/com/android/forceupdate/manager/ForceUpdateManager.kt
+++ b/forceupdate/src/main/java/com/android/forceupdate/manager/ForceUpdateManager.kt
@@ -9,6 +9,7 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.P
 import com.android.forceupdate.R
 import com.android.forceupdate.ui.ForceUpdateActivity
+import com.android.forceupdate.ui.ForceUpdateActivity.Companion.EXTRA_ANIMATION
 import com.android.forceupdate.ui.ForceUpdateActivity.Companion.EXTRA_APK_LINK
 import com.android.forceupdate.ui.ForceUpdateActivity.Companion.EXTRA_HEADER
 import com.android.forceupdate.ui.ForceUpdateActivity.Companion.EXTRA_OPTIONAL_DOWNLOAD
@@ -24,11 +25,17 @@ class ForceUpdateManager(private val activity: Activity) {
             updateVersion > packageInfo.versionCode
     }
 
-    fun updateApplication(apkLink: String, header: Pair<String, String>? = null, optional: Boolean = false) {
+    fun updateApplication(
+        apkLink: String,
+        header: Pair<String, String>? = null,
+        optional: Boolean = false,
+        animation: String? = null
+    ) {
         Intent(activity, ForceUpdateActivity::class.java).apply {
             this.putExtra(EXTRA_APK_LINK, apkLink)
             this.putExtra(EXTRA_OPTIONAL_DOWNLOAD, optional)
             header?.let { this.putExtra(EXTRA_HEADER, it) }
+            animation?.let { this.putExtra(EXTRA_ANIMATION, animation) }
             activity.startActivity(this)
         }
     }

--- a/forceupdate/src/main/java/com/android/forceupdate/repository/ForceUpdateRepositoryImpl.kt
+++ b/forceupdate/src/main/java/com/android/forceupdate/repository/ForceUpdateRepositoryImpl.kt
@@ -139,12 +139,11 @@ internal class ForceUpdateRepositoryImpl(private val context: Context) : ForceUp
         }
 
         contentResolver.openInputStream(localFile.toUri())?.use { apkStream ->
-            val length = DocumentFile.fromSingleUri(context, localFile.toUri())?.length() ?: -1
             val sessionParams = SessionParams(SessionParams.MODE_FULL_INSTALL)
             val sessionId = packageInstaller.createSession(sessionParams)
             val session = packageInstaller.openSession(sessionId)
 
-            session.openWrite(localFile.name, 0, length).use { sessionStream ->
+            session.openWrite(localFile.name, 0, -1).use { sessionStream ->
                 apkStream.copyTo(sessionStream)
                 session.fsync(sessionStream)
             }

--- a/forceupdate/src/main/java/com/android/forceupdate/ui/ForceUpdateActivity.kt
+++ b/forceupdate/src/main/java/com/android/forceupdate/ui/ForceUpdateActivity.kt
@@ -95,6 +95,11 @@ internal class ForceUpdateActivity : AppCompatActivity() {
         binding.message.text = getString(R.string.forceupdate_update_message, applicationName)
         binding.applicationName.text = applicationName
 
+        val animation = intent.getStringExtra(EXTRA_ANIMATION)
+        if (!animation.isNullOrEmpty() && animation.endsWith(".json"))
+            binding.animation.setAnimation(animation)
+        else binding.animation.setAnimation("force_update_animation.json")
+
         obtainStyledAttributes(TypedValue().data, intArrayOf(R.attr.colorPrimary)).use {
             val color = it.getColor(0, 0)
             binding.button.setTextColor(Color.WHITE)
@@ -162,6 +167,7 @@ internal class ForceUpdateActivity : AppCompatActivity() {
     companion object {
         const val EXTRA_APK_LINK = "link"
         const val EXTRA_HEADER = "header"
+        const val EXTRA_ANIMATION = "animation"
         const val EXTRA_OPTIONAL_DOWNLOAD = "optional"
     }
 }

--- a/forceupdate/src/main/res/layout/activity_force_update.xml
+++ b/forceupdate/src/main/res/layout/activity_force_update.xml
@@ -15,7 +15,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:lottie_autoPlay="true"
-        app:lottie_fileName="force_update_animation.json"
         app:lottie_loop="true" />
 
     <ImageView


### PR DESCRIPTION
Fix crash happened when using DocumentFile class. User now can add a custom loading animation to the force update screen